### PR TITLE
Compilation errors when using GCC on Cygwin

### DIFF
--- a/moves.cpp
+++ b/moves.cpp
@@ -23,6 +23,7 @@
 
 #include "moves.h"
 #include "magic.h"
+#include <stdlib.h>
 
 int rook_castle_to_squares[64];
 int rook_castle_from_squares[64];

--- a/uci.cpp
+++ b/uci.cpp
@@ -31,6 +31,7 @@
 #include <limits.h>
 #include <thread>
 #include <vector>
+#include <stdlib.h>
 
 using namespace std;
 

--- a/util.cpp
+++ b/util.cpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <stdlib.h>
 
 std::string pvstring_from_stack(int * pv, int size) {
 	std::string pv_string;


### PR DESCRIPTION
I have fixed three compilation errors when using GCC on Cygwin.
